### PR TITLE
fix OpenDirOptions.iterate=true to prevent panic in fs.cwd().openDir().iterate()

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -119,9 +119,9 @@ pub fn readJson(comptime T: type, allocator: Allocator, file_path: []const u8, o
 pub fn readDir(dir_path: []const u8) !Iterator {
 	const dir = blk: {
 		if (std.fs.path.isAbsolute(dir_path)) {
-			break :blk try std.fs.openDirAbsolute(dir_path, .{});
+			break :blk try std.fs.openDirAbsolute(dir_path, .{.iterate = true});
 		} else {
-			break :blk try std.fs.cwd().openDir(dir_path, .{});
+			break :blk try std.fs.cwd().openDir(dir_path, .{.iterate = true});
 		}
 	};
 


### PR DESCRIPTION
#### Problem
Zig standard library has an issue [Closed] #12007 https://github.com/ziglang/zig/issues/12007,
which requeres to set `OpenDirOptions.iterate=true` for `std.fs.openDirAbsolute()` etc, if we want to iterate the opened directory.

#### Reproduce
zig version: 0.12.0-dev.2750+5f9255829

`zig build test`

#### Result

```
.........thread 386773 panic: reached unreachable code
/opt/zig/lib/std/os.zig:5062:18: 0x116bcb1 in lseek_SET (test)
        .BADF => unreachable, // always a race condition
                 ^
/opt/zig/lib/std/fs/Dir.zig:343:40: 0x115fc04 in nextLinux (test)
                        posix.lseek_SET(self.dir.fd, 0) catch unreachable; // EBADF here likely means that the Dir was not opened with iteration permissions
                                       ^
/opt/zig/lib/std/fs/Dir.zig:327:34: 0x10eee97 in next (test)
            return self.nextLinux() catch |err| switch (err) {
                                 ^
/home/dad/projects/open-source/forks/zul/src/fs.zig:163:22: 0x10eedf8 in next (test)
  return self.it.next();
                     ^
/home/dad/projects/open-source/forks/zul/src/fs.zig:310:22: 0x10ef340 in test.fs.readDir: iterate (test)
   while (try it.next()) |entry| {
                     ^
/home/dad/projects/open-source/forks/zul/test_runner.zig:43:24: 0x10a6a75 in main (test)
  const result = t.func();
                       ^
/opt/zig/lib/std/start.zig:511:37: 0x10a178a in posixCallMainAndExit (test)
            const result = root.main() catch |err| {
                                    ^
/opt/zig/lib/std/start.zig:253:5: 0x10a12e1 in _start (test)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0x0 in ??? (???)
test
└─ run test failure
error: the following command terminated unexpectedly:
/home/dad/projects/open-source/forks/zul/zig-cache/o/877809e6c15178f21cfd5acb1470a64f/test
Build Summary: 1/3 steps succeeded; 1 failed (disable with --summary none)
test transitive failure
└─ run test failure
error: the following build command failed with exit code 1:
/home/dad/projects/open-source/forks/zul/zig-cache/o/169cde244f218bf0344175253995abab/build /opt/zig/zig /home/dad/projects/open-source/forks/zul /home/dad/projects/open-source/forks/zul/zig-cache /home/dad/.cache/zig --seed 0x247a7b35 -Zcb1f239bde67e419 test

```

#### Solution
Add iterate option when we open a Dir and iterate later `.{iterate = true}`


 

