### PR TITLE
std.json.reader removed

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -14,7 +14,12 @@ pub fn readJson(comptime T: type, allocator: Allocator, file_path: []const u8, o
     defer file.close();
 
     var buffered = std.io.bufferedReader(file.deprecatedReader());
-    var reader = std.json.reader(allocator, buffered.reader());
+    var new_interface = buffered.reader().adaptToNewApi(&buffered.buf).new_interface;
+
+    var reader: std.json.Reader = .init(
+        allocator,
+        &new_interface,
+    );
     defer reader.deinit();
 
     var o = opts;


### PR DESCRIPTION
Replaced one instance in fs.zig. Feels jank but passes tests.

There's another instance in http.zig that I'm not entirely comfortable with touching. The adapter for req reader requires a buffer, and didn't see any obvious existing buffers.